### PR TITLE
更新通道panic

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -51,6 +51,28 @@ type Channel struct {
 	*ChannelEx              //自定义属性
 }
 
+func (c *Channel) Copy(v *Channel) {
+	if v == nil {
+		return
+	}
+
+	c.DeviceID = v.DeviceID
+	c.ParentID = v.ParentID
+	c.Name = v.Name
+	c.Manufacturer = v.Manufacturer
+	c.Model = v.Model
+	c.Owner = v.Owner
+	c.CivilCode = v.CivilCode
+	c.Address = v.Address
+	c.Parental = v.Parental
+	c.SafetyWay = v.SafetyWay
+	c.RegisterWay = v.RegisterWay
+	c.Secrecy = v.Secrecy
+	c.Status = v.Status
+	c.Status = v.Status
+	c.ChannelEx = v.ChannelEx
+}
+
 func (c *Channel) CreateRequst(Method sip.RequestMethod) (req sip.Request) {
 	d := c.device
 	d.sn++


### PR DESCRIPTION
1.更新通道时会偶发panic，原因是channelMap中的值和Channels可能不是一个对象（只是DeviceID相同）
2.新增通道信息没有更新
3.删除通道时只删除了map中的信息，Channels中的对应信息没有删除