### PR TITLE
提交按需拉流场景的配置

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -405,14 +405,6 @@ func (channel *Channel) Invite(opt InviteOptions) (code int, err error) {
 		}
 		ack := sip.NewAckRequest("", invite, publisher.inviteRes, "", nil)
 		srv.Send(ack)
-		// 按需拉流场景下，由API_INVITE触发的推流不受DelayCloseTimeout的控制,模拟首次进行订阅者并退出；
-		if !conf.AutoInvite {
-			subscriber := &Subscriber{}
-			plugin.SubscribeExist(streamPath, subscriber)
-			time.AfterFunc(time.Second*time.Duration(conf.DelayCloseTimeout), func() {
-				subscriber.Stream.Receive(subscriber.Spesific)
-			})
-		}
 	} else if opt.IsLive() && conf.AutoInvite {
 		time.AfterFunc(time.Second*5, func() {
 			channel.Invite(InviteOptions{})

--- a/main.go
+++ b/main.go
@@ -59,11 +59,19 @@ func (c *GB28181Config) initRoutes() {
 	plugin.Info(fmt.Sprintf("LocalAndInternalIPs detail: %s", c.routes))
 }
 func (c *GB28181Config) OnEvent(event any) {
-	switch event.(type) {
+	switch v := event.(type) {
 	case FirstConfig:
 		ReadDevices()
 		go c.initRoutes()
 		c.startServer()
+	case *Stream:
+		// AutoInvite配置为false，启用按需拉流；
+		if !c.AutoInvite {
+			channel := FindChannel(v.AppName, v.StreamName)
+			if channel != nil && channel.LivePublisher == nil {
+				channel.Invite(InviteOptions{})
+			}
+		}
 	}
 }
 

--- a/restful.go
+++ b/restful.go
@@ -1,6 +1,8 @@
 package gb28181
 
 import (
+	"fmt"
+	"m7s.live/engine/v4"
 	"net/http"
 	"os"
 	"strconv"
@@ -54,8 +56,9 @@ func (conf *GB28181Config) API_invite(w http.ResponseWriter, r *http.Request) {
 	channel := query.Get("channel")
 	port, _ := strconv.Atoi(query.Get("mediaPort"))
 	opt := InviteOptions{
-		dump:      query.Get("dump"),
-		MediaPort: uint16(port),
+		dump:           query.Get("dump"),
+		MediaPort:      uint16(port),
+		InviteOnSubscribe: true,
 	}
 	opt.Validate(query.Get("startTime"), query.Get("endTime"))
 	if c := FindChannel(id, channel); c == nil {
@@ -108,6 +111,11 @@ func (conf *GB28181Config) API_bye(w http.ResponseWriter, r *http.Request) {
 	channel := r.URL.Query().Get("channel")
 	live := r.URL.Query().Get("live")
 	if c := FindChannel(id, channel); c != nil {
+		d := c.device
+		streamPath := fmt.Sprintf("%s/%s", d.ID, c.DeviceID)
+		if s := engine.Streams.Get(streamPath); s != nil {
+			s.Close()
+		}
 		w.WriteHeader(c.Bye(live != "false"))
 	} else {
 		http.NotFound(w, r)

--- a/utils/string.go
+++ b/utils/string.go
@@ -1,13 +1,14 @@
 package utils
 
 import (
-    "bytes"
-    "encoding/json"
-    "encoding/xml"
-    "golang.org/x/net/html/charset"
-    "golang.org/x/text/encoding/simplifiedchinese"
-    "golang.org/x/text/transform"
-    "io/ioutil"
+	"bytes"
+	"encoding/json"
+	"encoding/xml"
+	"golang.org/x/net/html/charset"
+	"golang.org/x/text/encoding/simplifiedchinese"
+	"golang.org/x/text/transform"
+	"io/ioutil"
+	"sort"
 )
 
 func ToJSONString(v interface{}) string {
@@ -20,22 +21,31 @@ func ToPrettyString(v interface{}) string {
 	return string(b)
 }
 
+func In(target string, strArray []string) bool {
+	sort.Strings(strArray)
+	index := sort.SearchStrings(strArray, target)
+	if index < len(strArray) && strArray[index] == target {
+		return true
+	}
+	return false
+}
+
 func GbkToUtf8(s []byte) ([]byte, error) {
-    reader := transform.NewReader(bytes.NewReader(s), simplifiedchinese.GBK.NewDecoder())
-    d, e := ioutil.ReadAll(reader)
-    if e != nil {
-        return s, e
-    }
-    return d, nil
+	reader := transform.NewReader(bytes.NewReader(s), simplifiedchinese.GBK.NewDecoder())
+	d, e := ioutil.ReadAll(reader)
+	if e != nil {
+		return s, e
+	}
+	return d, nil
 }
 
 func DecodeGbk(v interface{}, body []byte) error {
-    bodyBytes, err := GbkToUtf8(body)
-    if err != nil {
-        return err
-    }
-    decoder := xml.NewDecoder(bytes.NewReader(bodyBytes))
-    decoder.CharsetReader = charset.NewReaderLabel
-    err = decoder.Decode(v)
-    return err
+	bodyBytes, err := GbkToUtf8(body)
+	if err != nil {
+		return err
+	}
+	decoder := xml.NewDecoder(bytes.NewReader(bodyBytes))
+	decoder.CharsetReader = charset.NewReaderLabel
+	err = decoder.Decode(v)
+	return err
 }


### PR DESCRIPTION
1、新增按需Invite配置项inviteOnSubscribe，支持定义设备列表或正则表达式匹配。
2、监听最后一个订阅者离开事件，若属于按需Invite列表中的视频流，则通知Stream断开流。
3、修复Invite前bye()关闭流导致的snap插件阻塞读流的问题，关闭流转移至API_bye