### PR TITLE
调整和更新GB轨迹订阅和获取

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ _ "m7s.live/plugin/gb28181/v4"
 ```yaml
 gb28181:
   autoinvite:     true
+  position:
+    autosubposition: false #是否自动订阅定位
+    expires: 3600 #订阅周期(单位：秒)，默认3600
+    interval: 6 #订阅间隔（单位：秒），默认6
   prefetchrecord: false
   udpcachesize:   0
   sipnetwork:     udp
@@ -130,12 +134,12 @@ type Device struct {
 
 `/gb28181/api/invite`
 
-参数名 | 必传 | 含义
-|----|---|---
-id|是 | 设备ID
-channel|是|通道编号
-startTime|否|开始时间（纯数字Unix时间戳）
-endTime|否|结束时间（纯数字Unix时间戳）
+| 参数名    | 必传 | 含义                         |
+| --------- | ---- | ---------------------------- |
+| id        | 是   | 设备ID                       |
+| channel   | 是   | 通道编号                     |
+| startTime | 否   | 开始时间（纯数字Unix时间戳） |
+| endTime   | 否   | 结束时间（纯数字Unix时间戳） |
 
 返回200代表成功
 
@@ -143,38 +147,38 @@ endTime|否|结束时间（纯数字Unix时间戳）
 
 `/gb28181/api/bye`
 
-参数名 | 必传 | 含义
-|----|---|---
-id|是 | 设备ID
-channel|是|通道编号
+| 参数名  | 必传 | 含义     |
+| ------- | ---- | -------- |
+| id      | 是   | 设备ID   |
+| channel | 是   | 通道编号 |
 
 ### 发送控制命令
 
 `/gb28181/api/control`
 
-参数名 | 必传 | 含义
-|----|---|---
-id|是 | 设备ID
-channel|是|通道编号
-ptzcmd|是|PTZ控制指令
+| 参数名  | 必传 | 含义        |
+| ------- | ---- | ----------- |
+| id      | 是   | 设备ID      |
+| channel | 是   | 通道编号    |
+| ptzcmd  | 是   | PTZ控制指令 |
 
 ### 查询录像
 
 `/gb28181/api/records`
 
-参数名 | 必传 | 含义
-|----|---|---
-id|是 | 设备ID
-channel|是|通道编号
-startTime|否|开始时间（字符串，格式：2021-7-23T12:00:00）
-endTime|否|结束时间（字符串格式同上）
+| 参数名    | 必传 | 含义                                         |
+| --------- | ---- | -------------------------------------------- |
+| id        | 是   | 设备ID                                       |
+| channel   | 是   | 通道编号                                     |
+| startTime | 否   | 开始时间（字符串，格式：2021-7-23T12:00:00） |
+| endTime   | 否   | 结束时间（字符串格式同上）                   |
 
 ### 移动位置订阅
 
 `/gb28181/api/position`
 
-参数名 | 必传 | 含义
-|----|---|---
-id|是 | 设备ID
-expires|是|订阅周期（秒）
-interval|是|订阅间隔（秒）
+| 参数名   | 必传 | 含义           |
+| -------- | ---- | -------------- |
+| id       | 是   | 设备ID         |
+| expires  | 是   | 订阅周期（秒） |
+| interval | 是   | 订阅间隔（秒） |

--- a/channel.go
+++ b/channel.go
@@ -81,6 +81,7 @@ func (c *Channel) CreateRequst(Method sip.RequestMethod) (req sip.Request) {
 
 	callId := sip.CallID(utils.RandNumString(10))
 	userAgent := sip.UserAgentHeader("Monibuca")
+	maxForwards := sip.MaxForwards(70) //增加max-forwards为默认值 70
 	cseq := sip.CSeq{
 		SeqNo:      uint32(d.sn),
 		MethodName: Method,
@@ -118,6 +119,7 @@ func (c *Channel) CreateRequst(Method sip.RequestMethod) (req sip.Request) {
 			&callId,
 			&userAgent,
 			&cseq,
+			&maxForwards,
 			serverAddr.AsContactHeader(),
 		},
 		"",

--- a/handle.go
+++ b/handle.go
@@ -177,6 +177,11 @@ func (config *GB28181Config) OnMessage(req sip.Request, tx sip.ServerTransaction
 
 			}
 			d.CheckSubStream()
+			//在KeepLive 进行位置订阅的处理，如果开启了自动订阅位置，则去订阅位置
+			if config.Position.AutosubPosition && time.Since(d.GpsTime) > time.Duration(conf.Position.Interval*2)*time.Second {
+				d.MobilePositionSubscribe(d.ID, config.Position.Expires, config.Position.Interval)
+				plugin.Sugar().Debugf("位置自动订阅，设备[%s]成功\n", d.ID)
+			}
 		case "Catalog":
 			d.UpdateChannels(temp.DeviceList)
 		case "RecordInfo":

--- a/main.go
+++ b/main.go
@@ -9,6 +9,12 @@ import (
 	"m7s.live/engine/v4/config"
 )
 
+type GB28181PositionConfig struct {
+	AutosubPosition bool //是否自动订阅定位
+	Expires         int  //订阅周期(单位：秒)
+	Interval        int  //订阅间隔（单位：秒）
+}
+
 type GB28181Config struct {
 	AutoInvite     bool
 	PreFetchRecord bool
@@ -45,6 +51,8 @@ type GB28181Config struct {
 	LogLevel string //trace, debug, info, warn, error, fatal, panic
 	routes   map[string]string
 	DumpPath string //dump PS流本地文件路径
+
+	Position GB28181PositionConfig //关于定位的配置参数
 }
 
 func (c *GB28181Config) initRoutes() {
@@ -97,6 +105,7 @@ var conf = &GB28181Config{
 	RemoveBanInterval: 600,
 	LogLevel:          "info",
 	// WaitKeyFrame:      true,
+	Position: GB28181PositionConfig{AutosubPosition: true, Expires: 3600, Interval: 6},
 }
 
 var plugin = InstallPlugin(conf)


### PR DESCRIPTION
1.增加定位相关的配置设置
2.修复部分GB设备Header缺失maxForwards导致失败
3.增加自动获取设备定位
4.增加设备定位获取，支持单个或批量获取