### PR TITLE
修复对平台等非摄像头通道进行invite的问题

### DIFF
--- a/device.go
+++ b/device.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"golang.org/x/exp/maps"
 	"net/http"
 	"os"
 	"strings"
 	"sync"
 	"time"
+
+	"golang.org/x/exp/maps"
 
 	"go.uber.org/zap"
 	"m7s.live/engine/v4"
@@ -260,7 +261,7 @@ func (d *Device) UpdateChannels(list []*Channel) {
 				go c.QueryRecord(n.Format(TIME_LAYOUT), n.Add(time.Hour*24-time.Second).Format(TIME_LAYOUT))
 			}
 		}
-		if conf.AutoInvite && (c.LivePublisher == nil) {
+		if conf.AutoInvite && (c.LivePublisher == nil) && conf.CanInvite(c.DeviceID) {
 			go c.Invite(InviteOptions{})
 		}
 		if s := engine.Streams.Get("sub/" + c.DeviceID); s != nil {

--- a/handle.go
+++ b/handle.go
@@ -185,7 +185,7 @@ func (c *GB28181Config) OnMessage(req sip.Request, tx sip.ServerTransaction) {
 				go d.syncChannels()
 			} else {
 				for _, ch := range d.channelMap {
-					if c.AutoInvite && (ch.LivePublisher == nil) {
+					if c.AutoInvite && (ch.LivePublisher == nil) && c.CanInvite(ch.DeviceID) {
 						ch.Invite(InviteOptions{})
 					}
 				}

--- a/main.go
+++ b/main.go
@@ -18,6 +18,7 @@ type GB28181PositionConfig struct {
 
 type GB28181Config struct {
 	AutoInvite     bool
+	InviteIDs      string
 	PreFetchRecord bool
 
 	//sip服务器的配置
@@ -78,6 +79,35 @@ func (c *GB28181Config) OnEvent(event any) {
 
 func (c *GB28181Config) IsMediaNetworkTCP() bool {
 	return strings.ToLower(c.MediaNetwork) == "tcp"
+}
+
+func (c *GB28181Config) CanInvite(deviceID string) bool {
+	if len(deviceID) != 20 {
+		return false
+	}
+
+	if c.InviteIDs == "" {
+		return true
+	}
+
+	// 11～13位是设备类型编码
+	typeID := deviceID[10:13]
+
+	// format: start-end,type1,type2
+	tokens := strings.Split(c.InviteIDs, ",")
+	for _, tok := range tokens {
+		if first, second, ok := strings.Cut(tok, "-"); ok {
+			if typeID >= first && typeID <= second {
+				return true
+			}
+		} else {
+			if typeID == first {
+				return true
+			}
+		}
+	}
+
+	return false
 }
 
 var conf = &GB28181Config{


### PR DESCRIPTION
1. GBT 28181-2016标准文档附录D中的编码规则说明，11-13位编码是类型编码，可以表示设备类型。
2. 增加配置项inviteids，指定可以进行invite的设备类型编码，比如，宇视的摄像机编码，可以设置为“119-129,131,132”。
3. 代码中判断如果指定了inviteids，只对该范围内的设备进行invite，否则，保持之前逻辑。