### PR TITLE
兼容海康设备推流,处理流为tcp 协议时将sdp中y放到最后

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -449,11 +449,11 @@ func (channel *Channel) Invite(opt *InviteOptions) (code int, err error) {
 		fmt.Sprintf("m=video %d %sRTP/AVP 96", opt.MediaPort, protocol),
 		"a=recvonly",
 		"a=rtpmap:96 PS/90000",
-		"y=" + opt.ssrc,
 	}
 	if conf.IsMediaNetworkTCP() {
 		sdpInfo = append(sdpInfo, "a=setup:passive", "a=connection:new")
 	}
+	sdpInfo = append(sdpInfo, "y="+opt.ssrc)
 	invite := channel.CreateRequst(sip.INVITE)
 	contentType := sip.ContentType("application/sdp")
 	invite.AppendHeader(&contentType)


### PR DESCRIPTION
处理海康设备gb28181注册 sdp信息交换后 客户端回复415异常 定位后将sdp中y参数放到最后